### PR TITLE
plain madx files

### DIFF
--- a/madgui/component/comparetool.py
+++ b/madgui/component/comparetool.py
@@ -56,6 +56,8 @@ class CompareTool(object):
     def test_file(self):
         """Get the envelope file."""
         model = self.model.model
+        if not model:
+            return None
         optic = model._mdef['optics'][model._active['optic']]
         if 'test' in optic:
             return model.mdata.get_by_dict(optic['test'])

--- a/madgui/component/elementview.py
+++ b/madgui/component/elementview.py
@@ -40,7 +40,7 @@ class ElementView(object):
         """
 
         el = self.model.element_by_name(self.element_name)
-        rows = el.items()
+        rows = list(el._data.items())
 
         # convert to title case:
         rows = [(k.title(),v) for (k,v) in rows]

--- a/madgui/component/lhcmodels.py
+++ b/madgui/component/lhcmodels.py
@@ -1,0 +1,19 @@
+# encoding: utf-8
+"""
+Locator for LHC models.
+
+Should be moved to cpymad.
+"""
+
+# force new style imports
+from __future__ import absolute_import
+
+# 3rdparty
+from cern.cpymad.model_locator import ModelData, MergedModelLocator
+from cern.resource.package import PackageResource
+
+# exported symbols
+__all__ = ['locator']
+
+
+locator = MergedModelLocator(PackageResource('cern.cpymad', '_models'))

--- a/madgui/component/lineview.py
+++ b/madgui/component/lineview.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 # scipy
 import numpy as np
-from matplotlib.ticker import MultipleLocator
+from matplotlib.ticker import AutoMinorLocator
 
 # internal
 import madgui.core
@@ -195,10 +195,8 @@ class LineView(object):
 
         for axis_index, axis_name in enumerate(['x', 'y']):
             self.axes[axis_index].grid(True)
-            self.axes[axis_index].get_xaxis().set_minor_locator(
-                MultipleLocator(2))
-            self.axes[axis_index].get_yaxis().set_minor_locator(
-                MultipleLocator(2))
+            self.axes[axis_index].get_xaxis().set_minor_locator(AutoMinorLocator())
+            self.axes[axis_index].get_yaxis().set_minor_locator(AutoMinorLocator())
             self.axes[axis_index].set_xlim(stripunit(pos[0], self.unit.x),
                                            stripunit(pos[-1], self.unit.x))
             self.axes[axis_index].set_ylabel(r'$\Delta %s$ %s' % (

--- a/madgui/component/lineview.py
+++ b/madgui/component/lineview.py
@@ -80,7 +80,7 @@ class LineView(object):
     def draw_constraint(self, axis, elem, envelope):
         """Draw one constraint representation in the graph."""
         return self.axes[axis].plot(
-            stripunit(elem['at'], self.unit.x),
+            stripunit(elem.at, self.unit.x),
             stripunit(envelope, self.unit.y),
             's',
             color=self.curve[axis]['color'],
@@ -102,14 +102,12 @@ class LineView(object):
         """Return the element type name used for properties like coloring."""
         if 'type' not in elem or 'at' not in elem:
             return None
-        type_name = elem['type'].lower()
+        type_name = elem.type.lower()
         focussing = None
         if type_name == 'quadrupole':
-            i = self.model.get_element_index(elem)
-            focussing = stripunit(self.model.tw.k1l[i]) > 0
+            focussing = stripunit(elem.k1) > 0
         elif type_name == 'sbend':
-            i = self.model.get_element_index(elem)
-            focussing = stripunit(self.model.tw.angle[i]) > 0
+            focussing = stripunit(elem.angle) > 0
         if focussing is not None:
             if focussing:
                 type_name = 'f-' + type_name
@@ -132,11 +130,11 @@ class LineView(object):
         max_env = Vector(np.max(envx), np.max(envy))
         patch_h = Vector(0.75*stripunit(max_env.x, self.unit.y),
                          0.75*stripunit(max_env.y, self.unit.y))
-        for elem in self.model.sequence:
+        for elem in self.model.elements:
             elem_type = self.get_element_type(elem)
             if elem_type is None:
                 continue
-            if 'L' in elem and stripunit(elem['L']) != 0:
+            if stripunit(elem.L) != 0:
                 patch_w = stripunit(elem['L'], self.unit.x)
                 patch_x = stripunit(elem['at'], self.unit.x) - patch_w/2
                 self.axes.x.add_patch(
@@ -177,8 +175,7 @@ class LineView(object):
             label.set_visible(False)
         self.axes.y.yaxis.get_ticklabels()[0].set_visible(False)
 
-        if self.model.sequence:
-            self._drawelements()
+        self._drawelements()
 
         self.clines = Vector(
             self.axes.x.plot(

--- a/madgui/component/lineview.py
+++ b/madgui/component/lineview.py
@@ -127,6 +127,40 @@ class LineView(object):
         self.clines.y.set_ydata(stripunit(self.model.env.y, self.unit.y))
         self.figure.canvas.draw()
 
+    def _drawelements(self):
+        """Draw the elements into the canvas."""
+        envx, envy = self.model.env
+        max_env = Vector(np.max(envx), np.max(envy))
+        patch_h = Vector(0.75*stripunit(max_env.x, self.unit.y),
+                         0.75*stripunit(max_env.y, self.unit.y))
+        for elem in self.model.sequence:
+            elem_type = self.get_element_type(elem)
+            if elem_type is None:
+                continue
+            if 'L' in elem and stripunit(elem['L']) != 0:
+                patch_w = stripunit(elem['L'], self.unit.x)
+                patch_x = stripunit(elem['at'], self.unit.x) - patch_w/2
+                self.axes.x.add_patch(
+                    matplotlib.patches.Rectangle(
+                        (patch_x, 0),
+                        patch_w, patch_h.x,
+                        alpha=0.5, color=elem_type['color']))
+                self.axes.y.add_patch(
+                    matplotlib.patches.Rectangle(
+                        (patch_x, 0),
+                        patch_w, patch_h.y,
+                        alpha=0.5, color=elem_type['color']))
+            else:
+                patch_x = stripunit(elem['at'], self.unit.x)
+                self.axes.x.vlines(
+                    patch_x, 0,
+                    patch_h.x,
+                    alpha=0.5, color=elem_type['color'])
+                self.axes.y.vlines(
+                    patch_x, 0,
+                    patch_h.y,
+                    alpha=0.5, color=elem_type['color'])
+
     def plot(self):
 
         """Plot figure and redraw canvas."""
@@ -134,10 +168,6 @@ class LineView(object):
         # data post processing
         pos = self.model.pos
         envx, envy = self.model.env
-
-        max_env = Vector(np.max(envx), np.max(envy))
-        patch_h = Vector(0.75*stripunit(max_env.x, self.unit.y),
-                         0.75*stripunit(max_env.y, self.unit.y))
 
         # plot
         self.axes.x.cla()
@@ -148,34 +178,8 @@ class LineView(object):
             label.set_visible(False)
         self.axes.y.yaxis.get_ticklabels()[0].set_visible(False)
 
-        for elem in self.model.sequence:
-            elem_type = self.get_element_type(elem)
-            if elem_type is None:
-                continue
-
-            if 'L' in elem and stripunit(elem['L']) != 0:
-                patch_w = stripunit(elem['L'], self.unit.x)
-                patch_x = stripunit(elem['at'], self.unit.x) - patch_w/2
-                self.axes.x.add_patch(
-                        matplotlib.patches.Rectangle(
-                            (patch_x, 0),
-                            patch_w, patch_h.x,
-                            alpha=0.5, color=elem_type['color']))
-                self.axes.y.add_patch(
-                        matplotlib.patches.Rectangle(
-                            (patch_x, 0),
-                            patch_w, patch_h.y,
-                            alpha=0.5, color=elem_type['color']))
-            else:
-                patch_x = stripunit(elem['at'], self.unit.x)
-                self.axes.x.vlines(
-                        patch_x, 0,
-                        patch_h.x,
-                        alpha=0.5, color=elem_type['color'])
-                self.axes.y.vlines(
-                        patch_x, 0,
-                        patch_h.y,
-                        alpha=0.5, color=elem_type['color'])
+        if self.model.sequence:
+            self._drawelements()
 
         self.clines = Vector(
             self.axes.x.plot(

--- a/madgui/component/matchtool.py
+++ b/madgui/component/matchtool.py
@@ -28,20 +28,21 @@ class MatchTool(object):
         self.model = panel.view.model
         self.panel = panel
         self.view = panel.view
-        # toolbar tool
-        res = PackageResource('madgui.resource')
-        with res.open('cursor.xpm') as xpm:
-            img = wx.ImageFromStream(xpm, wx.BITMAP_TYPE_XPM)
-        bmp = wx.BitmapFromImage(img)
-        self.toolbar = panel.toolbar
-        self.tool = panel.toolbar.AddCheckTool(
-                wx.ID_ANY,
-                bitmap=bmp,
-                shortHelp='Beam matching',
-                longHelp='Match by specifying constraints for envelope x(s), y(s).')
-        panel.Bind(wx.EVT_TOOL, self.OnMatchClick, self.tool)
-        # setup mouse capture
-        panel.hook.capture_mouse.connect(self.stop_match)
+        if getattr(self.model, 'can_match', False):
+            # toolbar tool
+            res = PackageResource('madgui.resource')
+            with res.open('cursor.xpm') as xpm:
+                img = wx.ImageFromStream(xpm, wx.BITMAP_TYPE_XPM)
+            bmp = wx.BitmapFromImage(img)
+            self.toolbar = panel.toolbar
+            self.tool = panel.toolbar.AddCheckTool(
+                    wx.ID_ANY,
+                    bitmap=bmp,
+                    shortHelp='Beam matching',
+                    longHelp='Match by specifying constraints for envelope x(s), y(s).')
+            panel.Bind(wx.EVT_TOOL, self.OnMatchClick, self.tool)
+            # setup mouse capture
+            panel.hook.capture_mouse.connect(self.stop_match)
 
     def OnMatchClick(self, event):
         """Invoked when user clicks Match-Button"""

--- a/madgui/component/matchtool.py
+++ b/madgui/component/matchtool.py
@@ -40,8 +40,13 @@ class MatchTool(object):
                 shortHelp='Beam matching',
                 longHelp='Match by specifying constraints for envelope x(s), y(s).')
         panel.Bind(wx.EVT_TOOL, self.OnMatchClick, self.tool)
+        panel.Bind(wx.EVT_UPDATE_UI, self.UpdateTool, self.tool)
         # setup mouse capture
         panel.hook.capture_mouse.connect(self.stop_match)
+
+    def UpdateTool(self, event):
+        """Enable/disable toolbar tool."""
+        self.tool.Enable(self.model.can_match)
 
     def OnMatchClick(self, event):
         """Invoked when user clicks Match-Button"""

--- a/madgui/component/matchtool.py
+++ b/madgui/component/matchtool.py
@@ -28,21 +28,20 @@ class MatchTool(object):
         self.model = panel.view.model
         self.panel = panel
         self.view = panel.view
-        if getattr(self.model, 'can_match', False):
-            # toolbar tool
-            res = PackageResource('madgui.resource')
-            with res.open('cursor.xpm') as xpm:
-                img = wx.ImageFromStream(xpm, wx.BITMAP_TYPE_XPM)
-            bmp = wx.BitmapFromImage(img)
-            self.toolbar = panel.toolbar
-            self.tool = panel.toolbar.AddCheckTool(
-                    wx.ID_ANY,
-                    bitmap=bmp,
-                    shortHelp='Beam matching',
-                    longHelp='Match by specifying constraints for envelope x(s), y(s).')
-            panel.Bind(wx.EVT_TOOL, self.OnMatchClick, self.tool)
-            # setup mouse capture
-            panel.hook.capture_mouse.connect(self.stop_match)
+        # toolbar tool
+        res = PackageResource('madgui.resource')
+        with res.open('cursor.xpm') as xpm:
+            img = wx.ImageFromStream(xpm, wx.BITMAP_TYPE_XPM)
+        bmp = wx.BitmapFromImage(img)
+        self.toolbar = panel.toolbar
+        self.tool = panel.toolbar.AddCheckTool(
+                wx.ID_ANY,
+                bitmap=bmp,
+                shortHelp='Beam matching',
+                longHelp='Match by specifying constraints for envelope x(s), y(s).')
+        panel.Bind(wx.EVT_TOOL, self.OnMatchClick, self.tool)
+        # setup mouse capture
+        panel.hook.capture_mouse.connect(self.stop_match)
 
     def OnMatchClick(self, event):
         """Invoked when user clicks Match-Button"""
@@ -80,7 +79,7 @@ class MatchTool(object):
             return
         axis = 0 if axes is self.view.axes.x else 1
 
-        elem = self.model.element_by_position_center(
+        elem = self.model.element_by_position(
             event.xdata * self.view.unit.x)
         if elem is None or 'name' not in elem:
             return

--- a/madgui/component/model.py
+++ b/madgui/component/model.py
@@ -73,6 +73,13 @@ class Model(object):
             # TODO: init members
             pass
 
+    @property
+    def can_match(self):
+        return bool(self.twiss_args)
+
+    @property
+    def can_select(self):
+        return bool(self.elements)
 
     @property
     def beam(self):

--- a/madgui/component/model.py
+++ b/madgui/component/model.py
@@ -47,6 +47,7 @@ class Model(object):
 
     def __init__(self, model):
         """Load meta data and compute twiss variables."""
+        self._columns = ['name','s', 'l','betx','bety', 'angle', 'k1l']
         self.constraints = []
         self.model = model
         self.twiss()
@@ -122,9 +123,9 @@ class Model(object):
 
     def twiss(self):
         """Recalculate TWISS parameters."""
-        tw, self.summary = self.model.twiss(
-                columns=['name','s', 'l','betx','bety', 'angle', 'k1l'])
-        self.tw = self.from_madx(tw)
+        results = self.model.twiss(columns=self._columns)
+        self.tw = self.from_madx(results.columns.freeze(self._columns))
+        self.summary = self.from_madx(results.summary)
         self.update()
 
     def element_index_by_name(self, name):
@@ -207,10 +208,9 @@ class Model(object):
                     'range': elem['name'],
                     name: self.value_to_madx(name, envelope*envelope/emittance)})
 
-        tw, self.summary = self.model.match(
-            vary=vary,
-            constraints=constraints)
-        self.tw = self.from_madx(tw)
+        results = self.model.match(vary=vary, constraints=constraints)
+        self.tw = self.from_madx(results.columns.freeze(self._columns))
+        self.summary = self.from_madx(results.summary)
         self.update()
 
     def find_constraint(self, elem, axis=None):

--- a/madgui/component/model.py
+++ b/madgui/component/model.py
@@ -36,6 +36,8 @@ class Model(object):
      - knows sequence
      - knows about variables => can perform matching
     """
+    can_match = True
+    can_select = True
 
     hook = hookcollection(
         'madgui.component.model', [

--- a/madgui/component/model.py
+++ b/madgui/component/model.py
@@ -80,9 +80,7 @@ class Model(object):
     @property
     def beam(self):
         """Get the beam parameter dictionary."""
-        mdef = self.model._mdef
-        beam = mdef['sequences'][self.model._active['sequence']]['beam']
-        return self.from_madx(mdef['beams'][beam])
+        return self.from_madx(self.model.get_sequence().beam)
 
     def element_by_position(self, pos):
         """Find optics element by longitudinal position."""
@@ -166,10 +164,9 @@ class Model(object):
         """Perform post processing."""
         # data post processing
         self.pos = self.tw.s
-        beam = self.beam
         self.env = Vector(
-            (self.tw.betx * beam['ex'])**0.5,
-            (self.tw.bety * beam['ey'])**0.5)
+            (self.tw.betx * self.summary.ex)**0.5,
+            (self.tw.bety * self.summary.ey)**0.5)
         self.hook.update()
 
     def match(self):
@@ -193,10 +190,10 @@ class Model(object):
 
         # select constraints
         constraints = []
-        beam = self.beam
+        ex, ey = self.summary.ex, self.summary.ey
         for axis,elem,envelope in self.constraints:
             name = 'betx' if axis == 0 else 'bety'
-            emittance = beam['ex'] if axis == 0 else beam['ey']
+            emittance = ex if axis == 0 else ey
             if isinstance(envelope, tuple):
                 lower, upper = envelope
                 constraints.append([

--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -194,7 +194,8 @@ class OpenModelDlg(wx.Dialog):
         self.model = Model(cpymad_model._madx,
                            name=seqname,
                            twiss_args=cpymad_model._get_twiss_initial(),
-                           elements=seqobj.get_elements())
+                           elements=seqobj.get_elements(),
+                           model=cpymad_model)
 
     def TransferDataToWindow(self):
         """Update displayed package and model name."""

--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -157,11 +157,7 @@ class OpenModelDlg(wx.Dialog):
             return
         mdata = locator.get_model(self.ctrl_model.GetValue())
         histfile = os.path.join(self.logfolder, "%s.madx" % mdata.name)
-        res = mdata.repository.get()
-        self.model = Model(
-            name=mdata.name,
-            model=cpymad.model(mdata, histfile=histfile),
-            sequence=res.yaml('sequence.yml'))
+        self.model = Model(cpymad.model(mdata, histfile=histfile))
 
     def TransferDataToWindow(self):
         """Update displayed package and model name."""

--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 
 # standard library
 from importlib import import_module
-from collections import namedtuple
 from pkg_resources import iter_entry_points
 import os
 

--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -49,7 +49,9 @@ class OpenModelDlg(wx.Dialog):
         def OnOpenModel(event):
             dlg = cls(frame)
             if dlg.ShowModal() == wx.ID_OK:
-                dlg.model.hook.show(dlg.model, frame)
+                _frame = frame.Reserve(madx=dlg.model.model._madx,
+                                       model=dlg.model.model)
+                dlg.model.hook.show(dlg.model, _frame)
             dlg.Destroy()
         appmenu = menubar.Menus[0][0]
         menuitem = appmenu.Append(wx.ID_ANY,

--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -21,6 +21,8 @@ from madgui.core import wx
 from madgui.component.model import Model
 from madgui.util.common import cachedproperty
 
+# TODO: select sequence, optic, range
+
 
 class CachedLocator(object):
 
@@ -76,7 +78,8 @@ class OpenModelDlg(wx.Dialog):
         def OnOpenModel(event):
             dlg = cls(frame)
             if dlg.ShowModal() == wx.ID_OK:
-                _frame = frame.Reserve(madx=dlg.model.model._madx,
+                _frame = frame.Reserve(madx=dlg.model.madx,
+                                       control=dlg.model,
                                        model=dlg.model.model)
                 dlg.model.hook.show(dlg.model, _frame)
             dlg.Destroy()
@@ -184,7 +187,14 @@ class OpenModelDlg(wx.Dialog):
             return
         mdata = locator.get_model(self.ctrl_model.GetValue())
         # TODO: redirect history+output to frame!
-        self.model = Model(cpymad.model(mdata, histfile=None))
+        cpymad_model = cpymad.model(mdata, histfile=None)
+        cpymad_model.twiss()
+        seqname = cpymad_model._active['sequence']
+        seqobj = cpymad_model._madx.get_sequence(seqname)
+        self.model = Model(cpymad_model._madx,
+                           name=seqname,
+                           twiss_args=cpymad_model._get_twiss_initial(),
+                           elements=seqobj.get_elements())
 
     def TransferDataToWindow(self):
         """Update displayed package and model name."""

--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -61,7 +61,6 @@ class OpenModelDlg(wx.Dialog):
         """Store the data and initialize the component."""
         self.model = None
         super(OpenModelDlg, self).__init__(parent, *args, **kwargs)
-        self.logfolder = parent.logfolder
         self.CreateControls()
         self.Centre()
 
@@ -155,8 +154,8 @@ class OpenModelDlg(wx.Dialog):
             self.model = None
             return
         mdata = locator.get_model(self.ctrl_model.GetValue())
-        histfile = os.path.join(self.logfolder, "%s.madx" % mdata.name)
-        self.model = Model(cpymad.model(mdata, histfile=histfile))
+        # TODO: redirect history+output to frame!
+        self.model = Model(cpymad.model(mdata, histfile=None))
 
     def TransferDataToWindow(self):
         """Update displayed package and model name."""

--- a/madgui/component/plainopen.py
+++ b/madgui/component/plainopen.py
@@ -6,9 +6,6 @@ Dialog component to find/open a model.
 # force new style imports
 from __future__ import absolute_import
 
-# standard library
-import os
-
 # 3rd party
 from cern.cpymad.madx import Madx
 
@@ -28,11 +25,10 @@ def connect_menu(frame, menubar):
             model = Model(madx)
             model.call(dlg.Path)
             _frame = frame.Reserve(madx=madx,
-                                   control=model)
+                                   control=model,
+                                   model=model.model)
             try:
-                # TODO: detect active sequence (?) (should be done in cpymad!)
                 twiss = madx.get_active_sequence().twiss
-
             except (RuntimeError, ValueError):
                 pass
             else:

--- a/madgui/component/plainopen.py
+++ b/madgui/component/plainopen.py
@@ -21,12 +21,16 @@ def connect_menu(frame, menubar):
                             style=wx.FD_OPEN,
                             wildcard="MADX files (*.madx;*.str)|*.madx;*.str|All files (*.*)|*")
         if dlg.ShowModal() == wx.ID_OK:
+            name = dlg.Path
             madx = Madx()
-            model = Model(madx)
-            model.call(dlg.Path)
+            madx.call(name)
+            model = Model(madx, name=name)
             _frame = frame.Reserve(madx=madx,
                                    control=model,
-                                   model=model.model)
+                                   model=None,
+                                   name=name)
+            # TODO: iterate all available sequences (if there is no active
+            # sequence?) and ask the user which one to use.
             try:
                 twiss = madx.get_active_sequence().twiss
             except (RuntimeError, ValueError):

--- a/madgui/component/plainopen.py
+++ b/madgui/component/plainopen.py
@@ -1,0 +1,46 @@
+# encoding: utf-8
+"""
+Dialog component to find/open a model.
+"""
+
+# force new style imports
+from __future__ import absolute_import
+
+# standard library
+import os
+
+# 3rd party
+from cern.cpymad.madx import Madx
+
+# internal
+from madgui.core import wx
+from madgui.component.model import Model
+
+
+
+def connect_menu(frame, menubar):
+    def OnOpen(event):
+        dlg = wx.FileDialog(frame,
+                            style=wx.FD_OPEN,
+                            wildcard="MADX files (*.madx;*.str)|*.madx;*.str|All files (*.*)|*")
+        if dlg.ShowModal() == wx.ID_OK:
+            madx = Madx()
+            model = Model(madx)
+            model.call(dlg.Path)
+            _frame = frame.Reserve(madx=madx,
+                                   control=model)
+            try:
+                # TODO: detect active sequence (?) (should be done in cpymad!)
+                twiss = madx.get_active_sequence().twiss
+
+            except (RuntimeError, ValueError):
+                pass
+            else:
+                model.hook.show(model, _frame)
+        dlg.Destroy()
+    appmenu = menubar.Menus[0][0]
+    menuitem = appmenu.Append(wx.ID_ANY,
+                              'Load &MADX file\tCtrl+M',
+                              'Load a plain MADX file without any metadata.')
+    menubar.Bind(wx.EVT_MENU, OnOpen, menuitem)
+

--- a/madgui/component/selecttool.py
+++ b/madgui/component/selecttool.py
@@ -36,8 +36,13 @@ class SelectTool(object):
             shortHelp='Show info for individual elements',
             longHelp='Show info for individual elements')
         panel.Bind(wx.EVT_TOOL, self.OnSelectClick, self.tool)
+        panel.Bind(wx.EVT_UPDATE_UI, self.UpdateTool, self.tool)
         # setup mouse capture
         panel.hook.capture_mouse.connect(self.stop_select)
+
+    def UpdateTool(self, event):
+        """Enable/disable toolbar tool."""
+        self.tool.Enable(self.model.can_select)
 
     def OnSelectClick(self, event):
         """Invoked when user clicks Mirko-Button"""

--- a/madgui/component/selecttool.py
+++ b/madgui/component/selecttool.py
@@ -27,18 +27,17 @@ class SelectTool(object):
         self.model = panel.view.model
         self.panel = panel
         self.view = panel.view
-        if getattr(self.model, 'can_select', False):
-            # toolbar tool
-            bmp = wx.ArtProvider.GetBitmap(wx.ART_TIP, wx.ART_TOOLBAR)
-            self.toolbar = panel.toolbar
-            self.tool = panel.toolbar.AddCheckTool(
-                wx.ID_ANY,
-                bitmap=bmp,
-                shortHelp='Show info for individual elements',
-                longHelp='Show info for individual elements')
-            panel.Bind(wx.EVT_TOOL, self.OnSelectClick, self.tool)
-            # setup mouse capture
-            panel.hook.capture_mouse.connect(self.stop_select)
+        # toolbar tool
+        bmp = wx.ArtProvider.GetBitmap(wx.ART_TIP, wx.ART_TOOLBAR)
+        self.toolbar = panel.toolbar
+        self.tool = panel.toolbar.AddCheckTool(
+            wx.ID_ANY,
+            bitmap=bmp,
+            shortHelp='Show info for individual elements',
+            longHelp='Show info for individual elements')
+        panel.Bind(wx.EVT_TOOL, self.OnSelectClick, self.tool)
+        # setup mouse capture
+        panel.hook.capture_mouse.connect(self.stop_select)
 
     def OnSelectClick(self, event):
         """Invoked when user clicks Mirko-Button"""
@@ -63,7 +62,7 @@ class SelectTool(object):
 
     def on_select(self, event):
         """Display a popup window with info about the selected element."""
-        elem = self.model.element_by_position_center(
+        elem = self.model.element_by_position(
             event.xdata * self.view.unit.x)
         if elem is None or 'name' not in elem:
             return

--- a/madgui/component/selecttool.py
+++ b/madgui/component/selecttool.py
@@ -27,17 +27,18 @@ class SelectTool(object):
         self.model = panel.view.model
         self.panel = panel
         self.view = panel.view
-        # toolbar tool
-        bmp = wx.ArtProvider.GetBitmap(wx.ART_TIP, wx.ART_TOOLBAR)
-        self.toolbar = panel.toolbar
-        self.tool = panel.toolbar.AddCheckTool(
-            wx.ID_ANY,
-            bitmap=bmp,
-            shortHelp='Show info for individual elements',
-            longHelp='Show info for individual elements')
-        panel.Bind(wx.EVT_TOOL, self.OnSelectClick, self.tool)
-        # setup mouse capture
-        panel.hook.capture_mouse.connect(self.stop_select)
+        if getattr(self.model, 'can_select', False):
+            # toolbar tool
+            bmp = wx.ArtProvider.GetBitmap(wx.ART_TIP, wx.ART_TOOLBAR)
+            self.toolbar = panel.toolbar
+            self.tool = panel.toolbar.AddCheckTool(
+                wx.ID_ANY,
+                bitmap=bmp,
+                shortHelp='Show info for individual elements',
+                longHelp='Show info for individual elements')
+            panel.Bind(wx.EVT_TOOL, self.OnSelectClick, self.tool)
+            # setup mouse capture
+            panel.hook.capture_mouse.connect(self.stop_select)
 
     def OnSelectClick(self, event):
         """Invoked when user clicks Mirko-Button"""

--- a/madgui/core/app.py
+++ b/madgui/core/app.py
@@ -61,13 +61,6 @@ class App(wx.App):
 
         """Initialize the application and create main window."""
 
-        # create log directory
-        if self.args['--log']:
-            self.logfolder = self.args['--log']
-        else:
-            self.logfolder = os.path.join(os.path.expanduser('~'), '.madgui')
-        makedirs(self.logfolder)
-
         # allow plugin components to create stuff (frame!)
         self.hook.init(self)
 

--- a/madgui/core/notebook.py
+++ b/madgui/core/notebook.py
@@ -55,12 +55,16 @@ class NotebookFrame(wx.Frame):
             wx.aui.EVT_AUINOTEBOOK_PAGE_CLOSED,
             self.OnPageClosed,
             source=self.notebook)
+        self.notebook.Bind(
+            wx.aui.EVT_AUINOTEBOOK_PAGE_CLOSE,
+            self.OnPageClose,
+            source=self.notebook)
 
         # create menubar and listen to events:
         self.SetMenuBar(self._CreateMenu())
 
         # Create a command tab
-        self.NewCommandTab()
+        self._NewCommandTab()
 
         # show the frame
         self.Show(show)
@@ -73,10 +77,6 @@ class NotebookFrame(wx.Frame):
         appmenu = wx.Menu()
         menubar.Append(appmenu, '&App')
         # Create menu items
-        shellitem = appmenu.Append(wx.ID_ANY,
-                                   '&New prompt\tCtrl+N',
-                                   'Open a new tab with a command prompt')
-        self.Bind(wx.EVT_MENU, self.OnNewShell, shellitem)
         self.hook.menu(self, menubar)
         appmenu.AppendSeparator()
         appmenu.Append(wx.ID_EXIT, '&Quit', 'Quit application')
@@ -91,6 +91,11 @@ class NotebookFrame(wx.Frame):
         view.plot()
         return panel
 
+    def OnPageClose(self, event):
+        """Prevent the command tab from closing, if other tabs are open."""
+        if event.Selection == 0 and self.notebook.GetPageCount() > 1:
+            event.Veto()
+
     def OnPageClosed(self, event):
         """A page has been closed. If it was the last, close the frame."""
         if self.notebook.GetPageCount() == 0:
@@ -100,11 +105,7 @@ class NotebookFrame(wx.Frame):
         """Close the window."""
         self.Close()
 
-    def OnNewShell(self, event):
-        """Open a new command tab."""
-        self.NewCommandTab()
-
-    def NewCommandTab(self):
+    def _NewCommandTab(self):
         """Open a new command tab."""
         # TODO: create a toolbar for this tab as well
         # TODO: prevent the first command tab from being closed (?)

--- a/madgui/core/notebook.py
+++ b/madgui/core/notebook.py
@@ -44,6 +44,7 @@ class NotebookFrame(wx.Frame):
             size=wx.Size(800, 600))
 
         self.logfolder = app.logfolder
+        self.vars = {'views': []}
 
         # create notebook
         self.panel = wx.Panel(self)
@@ -89,6 +90,7 @@ class NotebookFrame(wx.Frame):
         panel = FigurePanel(self.notebook, view)
         self.notebook.AddPage(panel, title, select=True)
         view.plot()
+        self.vars['views'].append(view)
         return panel
 
     def OnPageClose(self, event):
@@ -100,6 +102,8 @@ class NotebookFrame(wx.Frame):
         """A page has been closed. If it was the last, close the frame."""
         if self.notebook.GetPageCount() == 0:
             self.Close()
+        else:
+            del self.vars['views'][event.Selection - 1]
 
     def OnQuit(self, event):
         """Close the window."""
@@ -107,7 +111,8 @@ class NotebookFrame(wx.Frame):
 
     def _NewCommandTab(self):
         """Open a new command tab."""
-        # TODO: create a toolbar for this tab as well
-        # TODO: prevent the first command tab from being closed (?)
         # TODO: redirect output?
-        self.notebook.AddPage(Crust(self.notebook), "Command", select=True)
+        self.notebook.AddPage(
+            Crust(self.notebook, locals=self.vars),
+            "Command",
+            select=True)

--- a/madgui/core/notebook.py
+++ b/madgui/core/notebook.py
@@ -43,7 +43,7 @@ class NotebookFrame(wx.Frame):
             title='MadGUI',
             size=wx.Size(800, 600))
 
-        self.logfolder = app.logfolder
+        self.app = app
         self.vars = {'views': []}
 
         # create notebook
@@ -65,6 +65,7 @@ class NotebookFrame(wx.Frame):
         self.SetMenuBar(self._CreateMenu())
 
         # Create a command tab
+        # TODO: create a log tab/pane
         self._NewCommandTab()
 
         # show the frame
@@ -111,7 +112,6 @@ class NotebookFrame(wx.Frame):
 
     def _NewCommandTab(self):
         """Open a new command tab."""
-        # TODO: redirect output?
         self.notebook.AddPage(
             Crust(self.notebook, locals=self.vars),
             "Command",

--- a/madgui/core/notebook.py
+++ b/madgui/core/notebook.py
@@ -71,6 +71,21 @@ class NotebookFrame(wx.Frame):
         # show the frame
         self.Show(show)
 
+    def Reserve(self, **vars):
+        """
+        Return a frame with some global variables.
+
+        If the variables exist within the current frame, a new frame will be
+        created. Otherwise, the same frame may be returned.
+        """
+        for k in vars:
+            if k in self.vars:
+                frame = self.__class__(self.app)
+                frame.vars.update(vars)
+                return frame
+        self.vars.update(vars)
+        return self
+
     def _CreateMenu(self):
         """Create a menubar."""
         # TODO: this needs to be done more dynamically. E.g. use resource

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'matplotlib',
         'numpy',
         'pydicti>=0.0.2',
-        'cern-pymad==0.6',
+        'cern-pymad==0.7',
         'unum>=4.0',
         'wxPython>=2.8',
         'docopt',

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ setup(
 
         [madgui.component.model.show]
         lineview = madgui.component.lineview:LineView.create
+
+        [madgui.models]
+        lhc = madgui.component.lhcmodels:locator
     """,
     package_data={
         'madgui': ['resource/*']

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
 
         [madgui.core.notebook.menu]
         openmodel = madgui.component.openmodel:OpenModelDlg.connect_menu
+        plainopen = madgui.component.plainopen:connect_menu
 
         [madgui.component.model.show]
         lineview = madgui.component.lineview:LineView.create


### PR DESCRIPTION
It is now possible to use multiple independent `Madx` instances, see [Redesign cpymad backend](https://github.com/pymad/pymad/pull/44).
This allows to process arbitrary madx files. A corresponding view has to be developed. It can probably act as a base class for the current `MadLineView` which is specialized for models.
Possibly, even elements can be shown, if madx files are preprocessed by [madseq](https://github.com/coldfix/madseq) or if implementing [inspect sequence from memory](https://github.com/pymad/pymad/issues/38).

In fact, this is a major concern and should be implemented ASAP, since it makes it easier to use custom .madx files ad-hoc without prior creation of model definitions.
