### PR TITLE
Immediately start a Madx instance for every new Frame

### DIFF
--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -91,13 +91,13 @@ class OpenModelDlg(ModalDialog):
                         return
                     detail = select_detail_dlg.data
                     # TODO: redirect history+output to frame!
+                    madx = frame.vars['madx']
                     cpymad_model = cpymad.model(mdata,
                                                 optics=[detail['optic']],
                                                 sequence=detail['sequence'],
-                                                histfile=None)
+                                                histfile=None,
+                                                madx=madx)
 
-                    madx = cpymad_model._madx
-                    madx.verbose(True)
                     beam = cpymad_model.get_beam(detail['beam'])
                     cpymad_model.set_beam(beam)
                     cpymad_model.set_range(detail['range'])
@@ -111,8 +111,7 @@ class OpenModelDlg(ModalDialog):
                                   twiss_args=utool.dict_from_madx(twiss_args),
                                   model=cpymad_model)
                     model.twiss()
-                    _frame = frame.Reserve(madx=madx,
-                                           control=model,
+                    _frame = frame.Reserve(control=model,
                                            model=cpymad_model)
                     model.hook.show(model, _frame)
                 finally:

--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -120,10 +120,16 @@ class OpenModelDlg(ModalDialog):
             finally:
                 select_model_dlg.Destroy()
         appmenu = menubar.Menus[0][0]
-        menuitem = appmenu.Append(wx.ID_ANY,
-                                  '&Open model\tCtrl+O',
-                                  'Open another model in a new tab')
+        menuitem = appmenu.Append(wx.ID_ANY, '&Open model\tCtrl+O')
+        def OnUpdate(event):
+            if frame.IsClaimed():
+                menuitem.SetHelp('Open a model in a new frame.')
+            else:
+                menuitem.SetHelp('Open a model in this frame.')
+            # skip the event, so more UpdateUI handlers can be invoked:
+            event.Skip()
         menubar.Bind(wx.EVT_MENU, OnOpenModel, menuitem)
+        menubar.Bind(wx.EVT_UPDATE_UI, OnUpdate, menubar)
 
     def SetData(self):
         """Store the data and initialize the component."""

--- a/madgui/component/openmodel.py
+++ b/madgui/component/openmodel.py
@@ -91,7 +91,8 @@ class OpenModelDlg(ModalDialog):
                         return
                     detail = select_detail_dlg.data
                     # TODO: redirect history+output to frame!
-                    madx = frame.vars['madx']
+                    _frame = frame.Claim()
+                    madx = _frame.vars['madx']
                     cpymad_model = cpymad.model(mdata,
                                                 optics=[detail['optic']],
                                                 sequence=detail['sequence'],
@@ -111,8 +112,8 @@ class OpenModelDlg(ModalDialog):
                                   twiss_args=utool.dict_from_madx(twiss_args),
                                   model=cpymad_model)
                     model.twiss()
-                    _frame = frame.Reserve(control=model,
-                                           model=cpymad_model)
+                    _frame.vars.update(control=model,
+                                       model=cpymad_model)
                     model.hook.show(model, _frame)
                 finally:
                     select_detail_dlg.Destroy()

--- a/madgui/component/plainopen.py
+++ b/madgui/component/plainopen.py
@@ -17,7 +17,8 @@ def connect_menu(frame, menubar):
                             style=wx.FD_OPEN,
                             wildcard="MADX files (*.madx;*.str)|*.madx;*.str|All files (*.*)|*")
         if dlg.ShowModal() == wx.ID_OK:
-            madx = frame.vars['madx']
+            _frame = frame.Claim()
+            madx = _frame.vars['madx']
             madx.call(dlg.Path)
             # look for sequences
             sequences = madx.get_sequence_names()
@@ -30,7 +31,7 @@ def connect_menu(frame, menubar):
                 # if there are multiple sequences - just ask the user which
                 # one to use rather than taking a wild guess based on twiss
                 # computation etc
-                dlg = wx.SingleChoiceDialog(parent=frame,
+                dlg = wx.SingleChoiceDialog(parent=_frame,
                                             caption="Select sequence",
                                             message="Select sequence:",
                                             choices=sequences)
@@ -39,9 +40,9 @@ def connect_menu(frame, menubar):
                 name = dlg.GetStringSelection()
             # now create the actual model object
             model = Model(madx, name=name)
-            _frame = frame.Reserve(control=model,
-                                   model=None,
-                                   name=name)
+            _frame.vars.update(control=model,
+                               model=None,
+                               name=name)
             if name:
                 model.hook.show(model, _frame)
         dlg.Destroy()

--- a/madgui/component/plainopen.py
+++ b/madgui/component/plainopen.py
@@ -6,9 +6,6 @@ Dialog component to find/open a .madx file.
 # force new style imports
 from __future__ import absolute_import
 
-# 3rd party
-from cern.cpymad.madx import Madx
-
 # internal
 from madgui.core import wx
 from madgui.component.model import Model
@@ -20,7 +17,7 @@ def connect_menu(frame, menubar):
                             style=wx.FD_OPEN,
                             wildcard="MADX files (*.madx;*.str)|*.madx;*.str|All files (*.*)|*")
         if dlg.ShowModal() == wx.ID_OK:
-            madx = Madx()
+            madx = frame.vars['madx']
             madx.call(dlg.Path)
             # look for sequences
             sequences = madx.get_sequence_names()
@@ -42,8 +39,7 @@ def connect_menu(frame, menubar):
                 name = dlg.GetStringSelection()
             # now create the actual model object
             model = Model(madx, name=name)
-            _frame = frame.Reserve(madx=madx,
-                                   control=model,
+            _frame = frame.Reserve(control=model,
                                    model=None,
                                    name=name)
             if name:

--- a/madgui/component/plainopen.py
+++ b/madgui/component/plainopen.py
@@ -47,8 +47,14 @@ def connect_menu(frame, menubar):
                 model.hook.show(model, _frame)
         dlg.Destroy()
     appmenu = menubar.Menus[0][0]
-    menuitem = appmenu.Append(wx.ID_ANY,
-                              'Load &MADX file\tCtrl+M',
-                              'Load a plain MADX file without any metadata.')
+    menuitem = appmenu.Append(wx.ID_ANY, 'Load &MAD-X file\tCtrl+M')
+    def OnUpdate(event):
+        if frame.IsClaimed():
+            menuitem.SetHelp('Open a .madx file in a new frame.')
+        else:
+            menuitem.SetHelp('Open a .madx file in this frame.')
+        # skip the event, so more UpdateUI handlers can be invoked:
+        event.Skip()
     menubar.Bind(wx.EVT_MENU, OnOpen, menuitem)
+    menubar.Bind(wx.EVT_UPDATE_UI, OnUpdate, menubar)
 

--- a/madgui/core/notebook.py
+++ b/madgui/core/notebook.py
@@ -97,6 +97,9 @@ class NotebookFrame(wx.Frame):
             self._claimed = True
             return self
 
+    def IsClaimed(self):
+        return self._claimed
+
     def _CreateMenu(self):
         """Create a menubar."""
         # TODO: this needs to be done more dynamically. E.g. use resource
@@ -141,6 +144,7 @@ class NotebookFrame(wx.Frame):
 
     def OnUpdateMenu(self, event):
         self.menubar.EnableTop(1, 'control' in self.vars)
+        event.Skip()
 
     def _NewCommandTab(self):
         """Open a new command tab."""

--- a/madgui/core/notebook.py
+++ b/madgui/core/notebook.py
@@ -46,6 +46,7 @@ class NotebookFrame(wx.Frame):
             title='MadGUI',
             size=wx.Size(800, 600))
 
+        self._claimed = False
         madx = Madx()
         libmadx = madx._libmadx
 
@@ -80,20 +81,21 @@ class NotebookFrame(wx.Frame):
         # show the frame
         self.Show(show)
 
-    def Reserve(self, **vars):
+    def Claim(self):
         """
-        Return a frame with some global variables.
+        Claim ownership of a frame.
 
-        If the variables exist within the current frame, a new frame will be
-        created. Otherwise, the same frame may be returned.
+        If this frame is already claimed, returns a new frame. If this frame
+        is not claimed, sets the status to claimed and returns self.
+
+        This is used to prevent several models/files to be opened in the
+        same frame (using the same Madx instance) with the menu actions.
         """
-        for k in vars:
-            if k in self.vars:
-                frame = self.__class__(self.app)
-                frame.vars.update(vars)
-                return frame
-        self.vars.update(vars)
-        return self
+        if self._claimed:
+            return self.__class__(self.app).Claim()
+        else:
+            self._claimed = True
+            return self
 
     def _CreateMenu(self):
         """Create a menubar."""

--- a/madgui/core/notebook.py
+++ b/madgui/core/notebook.py
@@ -11,6 +11,9 @@ import wx
 import wx.aui
 from wx.py.crust import Crust
 
+# 3rd party
+from cern.cpymad.madx import Madx
+
 # internal
 from madgui.util.common import ivar
 from madgui.util.plugin import HookCollection
@@ -43,8 +46,13 @@ class NotebookFrame(wx.Frame):
             title='MadGUI',
             size=wx.Size(800, 600))
 
+        madx = Madx()
+        libmadx = madx._libmadx
+
         self.app = app
-        self.vars = {'views': []}
+        self.vars = {'views': [],
+                     'madx': madx,
+                     'libmadx': libmadx}
 
         # create notebook
         self.panel = wx.Panel(self)


### PR DESCRIPTION
My currently preferred concept is the following: each frame exactly corresponds to one Madx instance. This makes "frame-global" variables (libmadx, madx, model, sequences) most convenient to access from the PyCrust shell.
