### PR TITLE
Make .madx with relative pathes usable

### DIFF
--- a/madgui/component/plainopen.py
+++ b/madgui/component/plainopen.py
@@ -19,7 +19,7 @@ def connect_menu(frame, menubar):
         if dlg.ShowModal() == wx.ID_OK:
             _frame = frame.Claim()
             madx = _frame.vars['madx']
-            madx.call(dlg.Path)
+            madx.call(dlg.Path, True)
             # look for sequences
             sequences = madx.get_sequence_names()
             if len(sequences) == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib==1.3.1
 numpy==1.8.1
 pydicti==0.0.4
-cern-pymad==0.7
+cern-pymad==0.8
 unum==4.1.3
 wxPython==3.0.0.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'matplotlib',
         'numpy',
         'pydicti>=0.0.4',
-        'cern-pymad==0.7',
+        'cern-pymad==0.8',
         'unum>=4.0',
         'wxPython>=2.8',
         'docopt',


### PR DESCRIPTION
Currently, .madx files containing relative pathes don't work. The easiest solution I can think of is to change the path temporarily before CALLing a file. NOTE: this needs to be done in the remote session.

This may need to be changed in the PyMAD code.

I think the simplest solution is to add a `chcwd` method to `cpymad.madx.Madx`.
