### PR TITLE
config file

### DIFF
--- a/madgui/__init__.py
+++ b/madgui/__init__.py
@@ -3,13 +3,13 @@
 MadGUI - interactive GUI application for MADX via cpymad.
 
 Usage:
-    madgui [-l <logs>]
+    madgui [--config <config>]
     madgui (--help | --version)
 
 Options:
-    -l <logs>, --log=<logs>     Set log directory (default is '~/.madgui')
-    -h, --help                  Show this help
-    -v, --version               Show version information
+    --config=<config>       Set config file
+    -h, --help              Show this help
+    -v, --version           Show version information
 
 Contact information:
 

--- a/madgui/core/app.py
+++ b/madgui/core/app.py
@@ -8,9 +8,11 @@ from __future__ import absolute_import
 
 # standard library
 import os
+import sys
 
-# GUI components
+# not so standard 3rdparty dependencies
 import wx
+import yaml
 
 # internal
 import madgui
@@ -19,6 +21,15 @@ from madgui.util.plugin import HookCollection
 
 # exported symbols
 __all__ = ['App']
+
+
+def _load_config(filename):
+    """Load a YAML configuration file."""
+    if filename:
+        with open(filename) as f:
+            return yaml.safe_load(f)
+    else:
+        return {}
 
 
 class App(wx.App):
@@ -46,15 +57,23 @@ class App(wx.App):
         """
         from docopt import docopt
         args = docopt(cls.usage, argv, version=cls.version)
-        cls(args).MainLoop()
+        config_file = args['--config']
+        if config_file is None:
+            config_file = os.path.join(os.path.expanduser('~'),
+                                       '.madgui', 'config.yml')
+            if os.path.exists(config_file):
+                config_file = None
+        conf = _load_config(config_file)
+        cls(args, conf).MainLoop()
 
-    def __init__(self, args=None):
+    def __init__(self, args=None, conf=None):
         """
         Create an application instance.
 
         :param dict args: preprocessed command line parameters
         """
         self.args = args
+        self.conf = conf
         super(App, self).__init__(redirect=False)
 
     def OnInit(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+cern-pymad==0.7
+docopt==0.6.1
 matplotlib==1.3.1
 numpy==1.8.1
 pydicti==0.0.4
-cern-pymad==0.7
-unum==4.1.3
+PyYAML==3.10
+Unum==4.1.3
 wxPython==3.0.0.0

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,14 @@ setup(
     license='MIT',
     test_suite='nose.collector',
     install_requires=[
+        'cern-pymad==0.7',
+        'docopt',
         'matplotlib',
         'numpy',
         'pydicti>=0.0.4',
-        'cern-pymad==0.7',
-        'unum>=4.0',
+        'PyYAML',
+        'Unum>=4.0',
         'wxPython>=2.8',
-        'docopt',
     ],
     entry_points="""
         [gui_scripts]


### PR DESCRIPTION
Use config file to store
- display options such as frame position/size
- fallback values for command line parameters

Config files can be accessed with [ConfigParser](http://docs.python.org/2.7/library/configparser.html).

Note, that the second issue probably is easier to accomplish using [argparse](http://docs.python.org/2.7/library/argparse.html) rather than [docopt](http://docopt.org/). It might be possible with _docopt_ to use a [`defaultdict`](http://docs.python.org/2.7/library/collections.html#collections.defaultdict) with one section of the config file as the fallback.
